### PR TITLE
Add code examples of semigroups and (endo)monoids in F#

### DIFF
--- a/pages/posts/reducers-are-monoids.mdx
+++ b/pages/posts/reducers-are-monoids.mdx
@@ -57,7 +57,7 @@ protocol Monoid : Semigroup {
 }
 ```
 
-```F#
+```fsharp
 type Semigroup<'a> =
     abstract member concat: 'a -> 'a -> 'a
 
@@ -96,7 +96,7 @@ newtype Endo a = Endo (a -> a)
 struct Endo<A> { let run: (A) -> A }
 ```
 
-```F#
+```fsharp
 type Endo<'a> = 'a -> 'a
 ```
 
@@ -136,7 +136,7 @@ struct Person {
 }
 ```
 
-```F#
+```fsharp
 type Person = {
     name : string
     age : int
@@ -193,7 +193,7 @@ let agedFred = { () in
 }
 ```
 
-```F#
+```fsharp
 let oneYearOlder: Endo<Person> = fun p -> { p with age = p.age + 1 }
 
 let agedFred =
@@ -271,7 +271,7 @@ let agedFred = { () in
 }
 ```
 
-```F#
+```fsharp
 let oneYearOlder: Endo<Person> = fun p -> { p with age = p.age + 1 }
 let addLastNameSmith: Endo<Person> = fun p -> { p with name = p.name + " Smith" }
 
@@ -337,7 +337,7 @@ change =
 // etc
 ```
 
-```F#
+```fsharp
 let change = PersonEndo.empty
 (* ... *)
 let change2 = PersonEndo.concat change (if aYearPasses then oneYearOlder else PersonEndo.empty)
@@ -366,7 +366,7 @@ end
 
 ```typescript
 const endoMonoid: <A>() => Monoid<Endo<A>> = () => ({
-    concat: (f, g) => x => g(f(x)),
+    concat: (f, g) => x => f(g(x)),
     empty: x => x
 });
 ```
@@ -390,13 +390,13 @@ extension Endo : Monoid {
 }
 ```
 
-```F#
+```fsharp
 type EndoMonoid<'a> () =
     interface Monoid<Endo<'a>> with
         member _.empty = fun x -> x
 
     interface Semigroup<Endo<'a>> with
-        member _.concat f g = fun x -> g (f x)
+        member _.concat f g = fun x -> f (g x)
 
 let PersonEndo = (new EndoMonoid<Person> ()) :> Monoid<Endo<Person>>
 ```
@@ -441,7 +441,7 @@ func liftPointwise<X, A>(
 }
 ```
 
-```F#
+```fsharp
 (* val liftPointwise :
     op: ('a -> 'b -> 'c) -> f1:('d -> 'a) -> f2:('d -> 'b) -> x:'d -> 'c *)
 let liftPointwise op = fun f1 f2 -> fun x -> op (f1 x) (f2 x)
@@ -505,7 +505,7 @@ extension Func: Monoid where A: Monoid {
 }
 ```
 
-```F#
+```fsharp
 type LiftPointWise<'x, 'a> (m: Monoid<'a>) =
     interface Monoid<'x -> 'a> with
         member _.empty = fun _ -> m.empty
@@ -544,7 +544,7 @@ reducer :: (state, action) -> state
 func reducer<S,A>(state: S, action: A) -> S
 ```
 
-```F#
+```fsharp
 type reducer<'state, 'action> = 'state * 'action -> 'state
 ```
 
@@ -614,7 +614,7 @@ func reducer<S,A>() -> Func<A, Endo<S>>
 // a monoid.
 ```
 
-```F#
+```fsharp
 type reducer<'state, 'action> = 'state * 'action -> 'state
 // flip the tuple
 type reducer<'state, 'action> = 'action * 'state -> 'state
@@ -634,7 +634,7 @@ And we have a monoid! You could say a reducer is just the $Endo_{state}$ monoid 
 
 Endofunctions are monoids, pointwise monoidal operations are monoids, and combining these two function-monoids give us reducers! The monoidal formulation of reducers obsoletes a need for a library to provide us a way to combine reducers and give us motivation for why reducers are such a nice way to manage changes to a larger application state.
 
-Thank you [Thomas Visser](https://twitter.com/thomvis) and [Stephen Celis](https://twitter.com/stephencelis) for pointing out some mistakes in early versions of this post!
+Thank you [Thomas Visser](https://twitter.com/thomvis) and [Stephen Celis](https://twitter.com/stephencelis) for pointing out some mistakes in early versions of this post! Thank you [Janne Siera](https://twitter.com/SieraSolutions) for adding F# examples to the post!
 
 ## Bonus: Stick it in a Writer Monad
 

--- a/pages/posts/reducers-are-monoids.mdx
+++ b/pages/posts/reducers-are-monoids.mdx
@@ -393,10 +393,10 @@ extension Endo : Monoid {
 ```F#
 type EndoMonoid<'a> () =
     interface Monoid<Endo<'a>> with
-        member this.empty = fun x -> x
+        member _.empty = fun x -> x
 
     interface Semigroup<Endo<'a>> with
-        member this.concat f g = fun x -> g (f x)
+        member _.concat f g = fun x -> g (f x)
 
 let PersonEndo = (new EndoMonoid<Person> ()) :> Monoid<Endo<Person>>
 ```
@@ -439,6 +439,14 @@ func liftPointwise<X, A>(
 ) -> (@escaping (X) -> A, @escaping (X) -> A) -> (X) -> A {
     return { f1, f2 in { x in op(f1(x), f2(x)) } }
 }
+```
+
+```F#
+(* val liftPointwise :
+    op: ('a -> 'b -> 'c) -> f1:('d -> 'a) -> f2:('d -> 'b) -> x:'d -> 'c *)
+let liftPointwise op = fun f1 f2 -> fun x -> op (f1 x) (f2 x)
+// or
+let liftPointwise op f1 f2 x = op (f1 x) (f2 x)
 ```
 
 </MultiCodeBlock>
@@ -497,6 +505,15 @@ extension Func: Monoid where A: Monoid {
 }
 ```
 
+```F#
+type LiftPointWise<'x, 'a> (m: Monoid<'a>) =
+    interface Monoid<'x -> 'a> with
+        member _.empty = fun _ -> m.empty
+
+    interface Semigroup<'x -> 'a> with
+        member _.concat f1 f2 = fun x -> m.concat (f1 x) (f2 x)
+```
+
 </MultiCodeBlock>
 
 Sometimes you want to manipulate functions over the operations rather than the underlying operations themselves. The nice thing is we don't have to give up our monoidal superpowers when we do so!
@@ -525,6 +542,10 @@ reducer :: (state, action) -> state
 
 ```swift
 func reducer<S,A>(state: S, action: A) -> S
+```
+
+```F#
+type reducer<'state, 'action> = 'state * 'action -> 'state
 ```
 
 </MultiCodeBlock>
@@ -591,6 +612,18 @@ func reducer<S,A>() -> Func<A, Endo<S>>
 // reducer is a monoid because Endo<S> is a
 // monoid, and it's a pointwise function into
 // a monoid.
+```
+
+```F#
+type reducer<'state, 'action> = 'state * 'action -> 'state
+// flip the tuple
+type reducer<'state, 'action> = 'action * 'state -> 'state
+// curry the function
+type reducer<'state, 'action> = 'action -> 'state -> 'state
+// rewrite (state -> state) to (Endo state)
+type reducer<'state, 'action> = 'action -> Endo<'state>
+// reducer is a monoid because (Endo state) is a monoid,
+// and it's a pointwise function into a monoid
 ```
 
 </MultiCodeBlock>

--- a/pages/posts/reducers-are-monoids.mdx
+++ b/pages/posts/reducers-are-monoids.mdx
@@ -57,6 +57,15 @@ protocol Monoid : Semigroup {
 }
 ```
 
+```F#
+type Semigroup<'a> =
+    abstract member concat: 'a -> 'a -> 'a
+
+type Monoid<'a> =
+    inherit Semigroup<'a>
+    abstract member empty: 'a
+```
+
 </MultiCodeBlock>
 
 ## Endofunctions are monoids
@@ -85,6 +94,10 @@ newtype Endo a = Endo (a -> a)
 
 ```swift
 struct Endo<A> { let run: (A) -> A }
+```
+
+```F#
+type Endo<'a> = 'a -> 'a
 ```
 
 </MultiCodeBlock>
@@ -120,6 +133,13 @@ data Person = Person
 struct Person {
   var name: String
   var age: Int
+}
+```
+
+```F#
+type Person = {
+    name : string
+    age : int
 }
 ```
 
@@ -171,6 +191,15 @@ let agedFred = { () in
   let fred_ = oneYearOlder.run(fred)
   return fred_ /* Person(name: "Fred", age: 21) */
 }
+```
+
+```F#
+let oneYearOlder: Endo<Person> = fun p -> { p with age = p.age + 1 }
+
+let agedFred =
+    let fred = { name = "Fred"; age = 20 }
+    let fred_ = oneYearOlder fred
+    fred_
 ```
 
 </MultiCodeBlock>
@@ -242,6 +271,17 @@ let agedFred = { () in
 }
 ```
 
+```F#
+let oneYearOlder: Endo<Person> = fun p -> { p with age = p.age + 1 }
+let addLastNameSmith: Endo<Person> = fun p -> { p with name = p.name + " Smith" }
+
+let agedFred =
+    let fred = { name = "Fred"; age = 20 }
+    let change = PersonEndo.concat oneYearOlder addLastNameSmith
+    let fred_ = change fred
+    fred_
+```
+
 </MultiCodeBlock>
 
 ### The Monoid
@@ -297,6 +337,13 @@ change =
 // etc
 ```
 
+```F#
+let change = PersonEndo.empty
+(* ... *)
+let change2 = PersonEndo.concat change (if aYearPasses then oneYearOlder else PersonEndo.empty)
+(* etc *)
+```
+
 </MultiCodeBlock>
 
 We can further improve on the above by utilizing a [writer monad as described in an older post](/posts/ocaml-writer) to remove all of the boilerplate doing something like the above.
@@ -341,6 +388,17 @@ extension Endo : Semigroup {
 extension Endo : Monoid {
   static var empty { return Endo { x in x } }
 }
+```
+
+```F#
+type EndoMonoid<'a> () =
+    interface Monoid<Endo<'a>> with
+        member this.empty = fun x -> x
+
+    interface Semigroup<Endo<'a>> with
+        member this.concat f g = fun x -> g (f x)
+
+let PersonEndo = (new EndoMonoid<Person> ()) :> Monoid<Endo<Person>>
 ```
 
 </MultiCodeBlock>


### PR DESCRIPTION
I added some examples of F# for the "reducers are monoids" post. I didn't get to the other examples (yet).

Also, I hope I didn't break the .mdx file with the angle brackets :P.